### PR TITLE
Add shebang to index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 'use strict'
 const system = require('@perl/system')
 const qx = require('@perl/qx')


### PR DESCRIPTION
Running assetize directly from the CLI throws errors because the script isn't interpreted via node. Adding a shebang fixes this issue.

Ref: #2